### PR TITLE
Add Next.js frontend for Railway deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,7 @@ Built with cutting-edge technologies:
 - TensorFlow.js for ML capabilities
 - React for user interfaces
 - Node.js for backend services
+
+## Frontend
+
+The repository now includes a Next.js frontend located in `frontend/`. Use `npm run dev` inside that directory to develop locally. Deployment to Railway is handled via the `railway.json` in the project root.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+.env.local

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function Home() {
+  const [backendStatus, setBackendStatus] = useState<string>('Checking...');
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+  
+  useEffect(() => {
+    fetch(`${apiUrl}/health`)
+      .then(res => res.ok ? 'Connected ✅' : 'Error ❌')
+      .catch(() => 'Offline ❌')
+      .then(setBackendStatus);
+  }, []);
+
+  return (
+    <main className="min-h-screen p-24">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-4xl font-bold mb-8">Field Elevate Hub</h1>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="p-6 border rounded-lg">
+            <h2 className="text-xl font-semibold mb-2">Frontend Status</h2>
+            <p className="text-green-500">✅ Running on Railway</p>
+          </div>
+          
+          <div className="p-6 border rounded-lg">
+            <h2 className="text-xl font-semibold mb-2">Backend Status</h2>
+            <p>API: {apiUrl}</p>
+            <p>Status: {backendStatus}</p>
+          </div>
+        </div>
+        
+        <div className="mt-8 p-6 bg-gray-100 rounded-lg">
+          <h3 className="font-semibold mb-2">Environment Info</h3>
+          <pre className="text-sm">
+            NODE_ENV: {process.env.NODE_ENV}
+            API URL: {apiUrl}
+          </pre>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    serverActions: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "field-elevate-frontend",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start -p ${PORT:-3000}",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/node": "^20.0.0",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "^5.3.3",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.33",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./app/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "cd frontend && npm ci && npm run build"
+  },
+  "deploy": {
+    "startCommand": "cd frontend && npm start",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10,
+    "rootDirectory": "frontend"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Next.js frontend application under `frontend/`
- configure Railway build and start commands via `railway.json`
- document frontend location in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b31f25ac832a83e714528a9426a8