### PR TITLE
Add simple PostgreSQL connectivity check script

### DIFF
--- a/check-db.js
+++ b/check-db.js
@@ -1,0 +1,23 @@
+require('dotenv').config();
+const { Sequelize } = require('sequelize');
+
+const dbUrl = process.env.DATABASE_URL;
+
+if (!dbUrl) {
+  console.error('DATABASE_URL environment variable is not set.');
+  process.exit(1);
+}
+
+const sequelize = new Sequelize(dbUrl, {
+  dialect: 'postgres',
+  logging: false
+});
+
+sequelize.authenticate()
+  .then(() => {
+    console.log('✅ Connected successfully!');
+    return sequelize.close();
+  })
+  .catch((err) => {
+    console.error('❌ Connection failed:', err.message);
+  });


### PR DESCRIPTION
## Summary
- add `check-db.js` to verify connectivity to a PostgreSQL database using Sequelize

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68497b8d0b18832a8658f8ad1047734f