### PR TITLE
Add Vercel config for frontend

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+VITE_API_URL=https://your-railway-backend.railway.app
+VITE_WEBSOCKET_URL=wss://your-railway-backend.railway.app
+VITE_APP_NAME=Field Elevate Hub
+# Add any other frontend environment variables

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+.env.local
+.vercel

--- a/frontend/README-VERCEL.md
+++ b/frontend/README-VERCEL.md
@@ -1,0 +1,24 @@
+# Vercel Frontend Deployment Guide
+
+## Prerequisites
+- Vercel account (sign up at vercel.com)
+- Railway backend deployed and running
+
+## Deployment Steps
+
+### 1. Deploy to Vercel
+Option A - Using Vercel CLI:
+```bash
+cd frontend
+npm install -g vercel
+vercel
+```
+Follow the CLI prompts to complete the deployment.
+
+Option B - Using Vercel Dashboard:
+1. Log in to the Vercel dashboard.
+2. Import this repository and select the `frontend` folder as the root.
+3. Set the environment variables defined in `.env.example`.
+4. Click **Deploy**.
+
+After deployment, Vercel will provide a URL for your frontend.

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,7 +5,7 @@ import { ComingSoon } from '@/components/ui/coming-soon';
 
 export default function Home() {
   const [features, setFeatures] = useState<Record<string, string>>({});
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+  const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
   useEffect(() => {
     const checkFeatures = async () => {

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,7 +1,7 @@
 export class APIClient {
   baseURL: string;
 
-  constructor(baseURL: string = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080') {
+  constructor(baseURL: string = import.meta.env.VITE_API_URL || 'http://localhost:3001') {
     this.baseURL = baseURL;
   }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
     "next": "14.1.0",

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,15 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "react",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ],
+  "env": {
+    "VITE_API_URL": "@production_api_url",
+    "VITE_WEBSOCKET_URL": "@production_websocket_url"
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_URL || 'http://localhost:3001',
+        changeOrigin: true,
+        secure: false,
+      }
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- configure Vercel deployment for the frontend
- provide example environment variables
- ignore build output and environment files
- switch frontend scripts to Vite and add proxy config
- update API calls to use env vars
- add deployment guide for Vercel

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684988120294832aa7dbb2ef57e5658d